### PR TITLE
fix(): Select the correct image for panning and scaling

### DIFF
--- a/src/components/ImageAdjust.tsx
+++ b/src/components/ImageAdjust.tsx
@@ -1,5 +1,5 @@
 import Slider from '@mui/material/Slider';
-import type { Canvas, FabricImage } from 'fabric';
+import type { Canvas } from 'fabric';
 import { util } from 'fabric';
 import { type RefObject, useCallback, useEffect, useState } from 'react';
 import { CardData } from '../contexts/fileDropper';
@@ -47,7 +47,7 @@ export const ImageAdjust = ({
     ({ target }: any) => {
       const { value } = target;
       const canvas = canvasRef.current!;
-      const image = canvas.getObjects('image')[0] as FabricImage;
+      const image =  getMainImage(canvas);
       image.scale(value);
       fixImageInsideCanvas(image);
       canvas.requestRenderAll();

--- a/src/hooks/useLabelEditor.ts
+++ b/src/hooks/useLabelEditor.ts
@@ -4,6 +4,7 @@ import { util, FabricImage, type StaticCanvas } from 'fabric';
 import { useAppDataContext } from '../contexts/appData';
 import { updateColors } from '../utils/updateColors';
 import { setTemplateV2OnCanvases } from '../utils/setTemplateV2';
+import { getMainImage } from '../utils/setTemplateV2';
 
 type useLabelEditorParams = {
   padderRef: MutableRefObject<HTMLDivElement | null>;
@@ -29,7 +30,7 @@ export const useLabelEditor = ({
           ? util.loadImage(URL.createObjectURL(file))
           : Promise.resolve(file);
       if (file) {
-        const currentImage = fabricCanvas.getObjects('image')[0];
+        const currentImage =  getMainImage(fabricCanvas);
         if (currentImage) {
           fabricCanvas.remove(currentImage);
         }


### PR DESCRIPTION
Long ago we were always selecting the image[0] on the templates.
Then we created templates v2 and with them the ability to use placeholder images in the graphics.
There is also a `getMainImage` function that finds the image that is correctly marked as main resource.