### PR TITLE
fix(): Excessive canvas size on screens with hi-dpi retina

### DIFF
--- a/src/components/FabricCanvasWrapper.tsx
+++ b/src/components/FabricCanvasWrapper.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect, useTransition } from 'react';
-import { StaticCanvas, FabricObject } from 'fabric';
+import { StaticCanvas } from 'fabric';
 
 type WrapperProp = {
   setFabricCanvas: (canvas: StaticCanvas | null) => void;
@@ -11,11 +11,10 @@ export const FabricCanvasWrapper = ({ setFabricCanvas }: WrapperProp) => {
 
   useEffect(() => {
     if (canvasRef.current) {
-      FabricObject.ownDefaults.originX = 'center';
-      FabricObject.ownDefaults.originY = 'center';
       const fabricCanvas = new StaticCanvas(canvasRef.current!, {
         renderOnAddRemove: false,
         backgroundColor: 'white',
+        enableRetinaScaling: false,
       });
       startTransition(() => {
         setFabricCanvas(fabricCanvas);


### PR DESCRIPTION
Now all canvases are constrain in a box of 900x900 px for display, but 450 display pixels, keeping a retina effect on good screens, while not being excessively large on normal screens.
While printing is still in vector mode.