### PR TITLE
Fix print issue with raster option

### DIFF
--- a/src/extensions/fabricToPdfKit.ts
+++ b/src/extensions/fabricToPdfKit.ts
@@ -463,6 +463,7 @@ export const addCanvasToPdfPage = async (
 
   if (asRaster) {
     const canvasClone = await canvas.clone([]);
+    canvasClone.viewportTransform = canvas.viewportTransform.slice() as TMat2D;
     canvasClone.getObjects().forEach((object: FabricObject) => {
       if (object['zaparoo-no-print']) {
         object.visible = false;


### PR DESCRIPTION
When cloning a canvas we need to manually port over the zoom and pan.
We started using zoom and pan recently on canvases and we didn't account this during the print process.

closes #134 