### PR TITLE
Add detection and conversion of non supported pdf images

### DIFF
--- a/src/contexts/appData.ts
+++ b/src/contexts/appData.ts
@@ -1,8 +1,5 @@
 import { createContext, useContext } from 'react';
-import {
-  defaultTemplate,
-  templates,
-} from '../cardsTemplates';
+import { defaultTemplate, templates } from '../cardsTemplates';
 import type { MediaDefinition, templateTypeV2 } from '../resourcesTypedef';
 import {
   type PrintTemplate,
@@ -14,8 +11,8 @@ import { noop } from '../utils/utils';
 export type PrintOptions = {
   imageType: 'raster' | 'vector';
   printerTemplateKey: string;
-  cutMarks: 'crop' | 'cut' | 'none',
-  outlines: boolean,
+  cutMarks: 'crop' | 'cut' | 'none';
+  outlines: boolean;
   fileType: 'pdf' | 'zip';
 };
 
@@ -24,7 +21,7 @@ export type contextType = {
   originalColors: string[];
   customColors: string[];
   template: templateTypeV2;
-  availableTemplates: (templateTypeV2)[];
+  availableTemplates: templateTypeV2[];
   mediaType: MediaDefinition;
   printerTemplate: PrintTemplate;
   printerTemplateKey: string;
@@ -44,15 +41,23 @@ export const defaultContextValue: contextType = {
   setIsIdle: noop,
   originalColors: [],
   customColors: [],
-  availableTemplates: Object.entries(templates).map(([key, value]) => ({ ...value, key, media : defaultTemplate.compatibleMedia[0] })).filter((t) => t.compatibleMedia.includes(defaultTemplate.compatibleMedia[0])),
+  availableTemplates: Object.entries(templates)
+    .map(([key, value]) => ({
+      ...value,
+      key,
+      media: defaultTemplate.compatibleMedia[0],
+    }))
+    .filter((t) =>
+      t.compatibleMedia.includes(defaultTemplate.compatibleMedia[0]),
+    ),
   mediaType: defaultTemplate.compatibleMedia[0],
   template: defaultTemplate,
   printerTemplate: defaultPrinterTemplate,
   printerTemplateKey: defaultPrinterTemplateKey,
   printOptions: {
-    imageType: 'raster',
+    imageType: 'vector',
     fileType: 'pdf',
-    cutMarks: 'none',
+    cutMarks: 'crop',
     outlines: true,
     printerTemplateKey: defaultPrinterTemplateKey,
   },

--- a/src/extensions/fabricToPdfKit.ts
+++ b/src/extensions/fabricToPdfKit.ts
@@ -18,6 +18,7 @@ import {
 } from 'fabric';
 import type { MediaDefinition, templateTypeV2 } from '../resourcesTypedef';
 import { getFontKey, registerFont } from './pdfFontCache';
+import { checkTypeOrFallback } from '../utils/checkTypeOrFallback';
 
 export const createDownloadStream = async (pdfDoc: any): Promise<Blob> => {
   // @ts-expect-error yeah no definitions
@@ -369,28 +370,22 @@ const addImageToPdf = async (
   const originalSize = fabricImage.getOriginalSize();
   // @ts-expect-error this isn't typed
   const originalFile = fabricImage.originalFile;
+  let arrayBuffer;
   if ((originalFile as File) instanceof File) {
     // @ts-expect-error this isn't typed
-    const arrayBuffer = await (fabricImage.originalFile as File).arrayBuffer();
-    pdfDoc.image(arrayBuffer, -fabricImage.width / 2, -fabricImage.height / 2, {
-      width: originalSize.width,
-      height: originalSize.height,
-    });
+    arrayBuffer = await (fabricImage.originalFile as File).arrayBuffer();
   } else if (originalFile) {
-    const imageFetch = await (await fetch(originalFile.src)).arrayBuffer();
-    pdfDoc.image(imageFetch, -fabricImage.width / 2, -fabricImage.height / 2, {
-      width: originalSize.width,
-      height: originalSize.height,
-    });
+    arrayBuffer = await (await fetch(originalFile.src)).arrayBuffer();
   } else {
     // todo fix
     // images part of the template will likely be duplicated.
-    const imageFetch = await (await fetch(fabricImage.getSrc())).arrayBuffer();
-    pdfDoc.image(imageFetch, -fabricImage.width / 2, -fabricImage.height / 2, {
-      width: originalSize.width,
-      height: originalSize.height,
-    });
+    arrayBuffer = await (await fetch(fabricImage.getSrc())).arrayBuffer();
   }
+  arrayBuffer = await checkTypeOrFallback(arrayBuffer, fabricImage);
+  pdfDoc.image(arrayBuffer, -fabricImage.width / 2, -fabricImage.height / 2, {
+    width: originalSize.width,
+    height: originalSize.height,
+  });
   pdfDoc.restore();
 };
 

--- a/src/utils/checkTypeOrFallback.ts
+++ b/src/utils/checkTypeOrFallback.ts
@@ -1,0 +1,57 @@
+import { type FabricImage } from 'fabric';
+
+const isPng = (buffer: Uint8Array): boolean => {
+  if (!buffer || buffer.length < 8) {
+    return false;
+  }
+
+  return (
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  );
+};
+
+export default function isJpg(buffer: Uint8Array) {
+  if (!buffer || buffer.length < 3) {
+    return false;
+  }
+
+  return buffer[0] === 255 && buffer[1] === 216 && buffer[2] === 255;
+}
+
+/**
+ * Detectes if the buffer is of type jpeg or png, if not, takes fabricImage._element and return
+ * a converted version of it to png via canvas painting and export.
+ * @param buffer
+ * @param fabricImage
+ */
+export const checkTypeOrFallback = async (
+  buffer: ArrayBuffer,
+  fabricImage: FabricImage,
+): Promise<ArrayBuffer> => {
+  const headCopy = buffer.slice(0, 8);
+  const view = new Uint8Array(headCopy);
+  if (isPng(view) || isJpg(view)) {
+    return buffer;
+  }
+  const clip = fabricImage.clipPath;
+  fabricImage.clipPath = undefined;
+
+  const buffPromise = (await fabricImage.toBlob({
+    left: 0,
+    top: 0,
+    enableRetinaScaling: false,
+    viewportTransform: false,
+    withoutTransform: true,
+    withoutShadow: true,
+  }))!.arrayBuffer();
+
+  fabricImage.clipPath = clip;
+  return buffPromise;
+};


### PR DESCRIPTION
Checks if an image is png or jpeg and then convert it to a png before adding it to the pdf.
Works at least with WEBP/GIF.

closes #136