### PR TITLE
Fix export for zip download of tap trading cards

### DIFF
--- a/src/utils/prepareZip.ts
+++ b/src/utils/prepareZip.ts
@@ -1,33 +1,42 @@
 import type { InputWithSizeMeta } from 'client-zip';
 import { downloadBlob } from './utils';
 import { CardData } from '../contexts/fileDropper';
+import { type FabricObject } from 'fabric';
 
 export const prepareZip = async (cards: CardData[]) => {
   const { downloadZip } = await import('client-zip');
-  const canvases = cards.map(card => card.canvas!);
+  const canvases = cards.map((card) => card.canvas!);
   if (canvases) {
     const inputs = await Promise.all(
-      canvases.map<Promise<InputWithSizeMeta>>((canvas, index) => {
-        const referenceObject = (canvas.backgroundImage ||
-          canvas.overlayImage ||
-          canvas.clipPath)!;
-        const { top, left, width, height } = referenceObject!.getBoundingRect();
-        // TODO: the top and left values should take in account of viewport translations
-        const htmlCanvas = canvas.toCanvasElement(2 / canvas.getZoom(), {
-          top: top * canvas.getZoom(),
-          left: left * canvas.getZoom(),
-          width: width * canvas.getZoom(),
-          height: height * canvas.getZoom(),
-        });
-        return new Promise((resolve) => {
-          htmlCanvas.toBlob((blob: Blob | null) => {
-            blob &&
-              resolve({
-                name: `label_${index}.png`,
-                lastModified: Date.now(),
-                input: blob,
-                size: blob.size,
-              });
+      canvases.map<Promise<InputWithSizeMeta>>((origiCanvas, index) => {
+        return origiCanvas.clone([]).then((canvas) => {
+          canvas.getObjects().forEach((object: FabricObject) => {
+            if (object['zaparoo-no-print']) {
+              object.visible = false;
+            }
+          });
+          const referenceObject = (canvas.backgroundImage ||
+            canvas.overlayImage ||
+            canvas.clipPath)!;
+          const { top, left, width, height } =
+            referenceObject!.getBoundingRect();
+          // TODO: the top and left values should take in account of viewport translations
+          const htmlCanvas = canvas.toCanvasElement(2 / canvas.getZoom(), {
+            top: top * canvas.getZoom(),
+            left: left * canvas.getZoom(),
+            width: width * canvas.getZoom(),
+            height: height * canvas.getZoom(),
+          });
+          return new Promise((resolve) => {
+            htmlCanvas.toBlob((blob: Blob | null) => {
+              blob &&
+                resolve({
+                  name: `label_${index}.png`,
+                  lastModified: Date.now(),
+                  input: blob,
+                  size: blob.size,
+                });
+            });
           });
         });
       }),


### PR DESCRIPTION
This is not the perfect fix, but more a good enough solution. for people wanting to cut those labels correctly.
In order to do things in a good way i need to introduce an extra extra clipPath in the export.

This for now makes the zip usable again. a better fix will follow

closes #138