### PR TITLE
fix: restore vertical panel scrolling in Firefox

### DIFF
--- a/src/componentsV2/LabelsView.css
+++ b/src/componentsV2/LabelsView.css
@@ -34,15 +34,23 @@
 .resourceListAreaLogos {
   column-count: 2;
   column-gap: 8px;
-  overflow-y: scroll;
   padding-left: 8px;
   padding-right: 0px;
   box-sizing: border-box;
   width: 100%;
 }
 
-.resourceListAreaLogos.noScroll {
-  overflow-y: hidden;
+.resourceListAreaLogosScroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  width: 100%;
+}
+
+.resourcePanelSection {
+  flex: 1;
+  min-height: 0;
 }
 
 .verticalStack.leftPanel {

--- a/src/componentsV2/panels/ConsoleDisplay.tsx
+++ b/src/componentsV2/panels/ConsoleDisplay.tsx
@@ -32,18 +32,20 @@ export const ConsoleDisplay = ({ canvasRef, blocked }: ConsoleDisplayProps) => {
           onChange={searchHandler}
         />
       </div>
-      <div className="resourceListAreaLogos">
-        {consoles.map(
-          (console, index) =>
-            console.name.toLowerCase().includes(keyword) && (
-              <ImagePanelDisplay
-                blocked={blocked}
-                key={`${console.name}-${index}`}
-                canvasRef={canvasRef}
-                imageResult={{ url: console.url, width: 400, height: 400 }}
-              />
-            ),
-        )}
+      <div className="resourceListAreaLogosScroll">
+        <div className="resourceListAreaLogos">
+          {consoles.map(
+            (console, index) =>
+              console.name.toLowerCase().includes(keyword) && (
+                <ImagePanelDisplay
+                  blocked={blocked}
+                  key={`${console.name}-${index}`}
+                  canvasRef={canvasRef}
+                  imageResult={{ url: console.url, width: 400, height: 400 }}
+                />
+              ),
+          )}
+        </div>
       </div>
     </>
   );

--- a/src/componentsV2/panels/ControllerDisplay.tsx
+++ b/src/componentsV2/panels/ControllerDisplay.tsx
@@ -32,18 +32,20 @@ export const ControllerDisplay = ({ canvasRef, blocked }: LogoTabsProps) => {
           onChange={searchHandler}
         />
       </div>
-      <div className="resourceListAreaLogos">
-        {controllers.map(
-          (controller) =>
-            controller.name.toLowerCase().includes(keyword) && (
-              <ImagePanelDisplay
-                blocked={blocked}
-                key={controller.name}
-                canvasRef={canvasRef}
-                imageResult={{ url: controller.url, width: 400, height: 400 }}
-              />
-            ),
-        )}
+      <div className="resourceListAreaLogosScroll">
+        <div className="resourceListAreaLogos">
+          {controllers.map(
+            (controller) =>
+              controller.name.toLowerCase().includes(keyword) && (
+                <ImagePanelDisplay
+                  blocked={blocked}
+                  key={controller.name}
+                  canvasRef={canvasRef}
+                  imageResult={{ url: controller.url, width: 400, height: 400 }}
+                />
+              ),
+          )}
+        </div>
       </div>
     </>
   );

--- a/src/componentsV2/panels/HardwareResourcesPanel.tsx
+++ b/src/componentsV2/panels/HardwareResourcesPanel.tsx
@@ -24,7 +24,7 @@ export function HardwareResourcesPanel({
   };
 
   return (
-    <PanelSection title="Hardware">
+    <PanelSection title="Hardware" className="resourcePanelSection">
       {hasCards && !isEditing && <SuggestDrag />}
       {hasCards && isEditing && <SuggestClick />}
       {hasCards || <RequireCards />}

--- a/src/componentsV2/panels/LogosTabs.css
+++ b/src/componentsV2/panels/LogosTabs.css
@@ -9,9 +9,8 @@
   flex: 1;
 }
 
-.resourceListAreaLogos.loadingArea {
+.resourceListAreaLogosScroll.loadingArea {
   display: flex;
   align-items: center;
   justify-content: center;
-  flex: 1;
 }

--- a/src/componentsV2/panels/LogosTabs.tsx
+++ b/src/componentsV2/panels/LogosTabs.tsx
@@ -47,7 +47,10 @@ export const LogoTabs = ({ canvasRef, isEditing, hasCards }: LogoTabsProps) => {
   );
 
   return (
-    <PanelSection title="Company logos" className={!hasLogos ? 'panelLoading' : ''}>
+    <PanelSection
+      title="Company logos"
+      className={`resourcePanelSection ${!hasLogos ? 'panelLoading' : ''}`}
+    >
       {hasCards && !isEditing && <SuggestDrag />}
       {hasCards && isEditing && <SuggestClick />}
       {hasCards || <RequireCards />}
@@ -85,20 +88,23 @@ export const LogoTabs = ({ canvasRef, isEditing, hasCards }: LogoTabsProps) => {
           </Select>
         </FormControl>
       </div>
-      <div className={`resourceListAreaLogos ${!hasLogos ? 'loadingArea' : ''}`}>
-        {!hasLogos && (
+      <div className={`resourceListAreaLogosScroll ${!hasLogos ? 'loadingArea' : ''}`}>
+        {!hasLogos ? (
           <CircularProgress />
-        )}
-        {logos.map(
-          (logo) =>
-            logo.name.toLowerCase().includes(keyword) && (
-              <ImagePanelDisplay
-                blocked={!hasCards}
-                key={logo.url}
-                canvasRef={canvasRef}
-                imageResult={{ url: logo.url, width: logo.width, height: logo.height }}
-              />
-            ),
+        ) : (
+          <div className="resourceListAreaLogos">
+            {logos.map(
+              (logo) =>
+                logo.name.toLowerCase().includes(keyword) && (
+                  <ImagePanelDisplay
+                    blocked={!hasCards}
+                    key={logo.url}
+                    canvasRef={canvasRef}
+                    imageResult={{ url: logo.url, width: logo.width, height: logo.height }}
+                  />
+                ),
+            )}
+          </div>
         )}
       </div>
     </PanelSection>

--- a/src/componentsV2/panels/TemplatePanel.tsx
+++ b/src/componentsV2/panels/TemplatePanel.tsx
@@ -30,7 +30,7 @@ export const TemplatePanel = ({ canvasRef, hasCards }: TemplatePanelProps) => {
   const allSelected = hasCards && selectedCardsCount === cards.current.length;
 
   return (
-    <PanelSection title="Templates">
+    <PanelSection title="Templates" className="resourcePanelSection">
       {hasCards && selectedCardsCount === 0 && (
         <Alert
           style={{ width: '100%', boxSizing: 'border-box' }}
@@ -85,20 +85,22 @@ export const TemplatePanel = ({ canvasRef, hasCards }: TemplatePanelProps) => {
           )}
         </FormControl>
       </div>
-      <div className="resourceListAreaLogos">
-        {availableTemplates.map((templateTypeV2) => (
-          <ImagePanelDisplay
-            key={templateTypeV2.key}
-            canvasRef={canvasRef}
-            onClick={() => setTemplate(templateTypeV2)}
-            active={templateTypeV2.key === template.key}
-            imageResult={{
-              url: templateTypeV2.preview,
-              width: 400,
-              height: 400,
-            }}
-          />
-        ))}
+      <div className="resourceListAreaLogosScroll">
+        <div className="resourceListAreaLogos">
+          {availableTemplates.map((templateTypeV2) => (
+            <ImagePanelDisplay
+              key={templateTypeV2.key}
+              canvasRef={canvasRef}
+              onClick={() => setTemplate(templateTypeV2)}
+              active={templateTypeV2.key === template.key}
+              imageResult={{
+                url: templateTypeV2.preview,
+                width: 400,
+                height: 400,
+              }}
+            />
+          ))}
+        </div>
       </div>
     </PanelSection>
   );


### PR DESCRIPTION
## Summary
- separate the scroll container from the multi-column logo/template/resource grid
- make the affected V2 panel sections flex correctly with `min-height: 0` so Firefox gets a real vertical scroll area
- apply the shared panel layout fix to logos, templates, consoles, and controllers

## Testing
- yarn test
- yarn build

Closes #151